### PR TITLE
CircleCI changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: denoland/deno:1.19.0
     steps:
-      - run: apt-get update -yqq && apt-get install git -yqq && git clone -b ${CIRCLE_BRANCH} https://github.com/jonbaldie/queue.git && cd queue && touch persist.dat && deno compile --allow-read --allow-write --allow-net --allow-env main.ts && cp ./queue /usr/bin/ && deno test --allow-read --allow-write --allow-net 
+      - run: apt-get update -yqq && apt-get install git -yqq && git clone -b ${CIRCLE_BRANCH} https://github.com/jonbaldie/queue.git && cd queue && touch persist.dat && deno compile --allow-read --allow-write --allow-net --allow-env main.ts && cp ./queue /usr/bin/ && deno test --allow-read --allow-write --allow-net
 
 workflows:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: denoland/deno:1.19.0
     steps:
-      - run: apt-get update -yqq && apt-get install git -yqq && git clone -b ${CIRCLE_BRANCH} https://github.com/jonbaldie/queue.git && cd queue && deno compile --allow-read --allow-write --allow-net --allow-env main.ts && cp ./queue /usr/bin/ && deno test --allow-read --allow-write --allow-net 
+      - run: apt-get update -yqq && apt-get install git -yqq && git clone -b ${CIRCLE_BRANCH} https://github.com/jonbaldie/queue.git && cd queue && touch persist.dat && deno compile --allow-read --allow-write --allow-net --allow-env main.ts && cp ./queue /usr/bin/ && deno test --allow-read --allow-write --allow-net 
 
 workflows:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: denoland/deno:1.19.0
     steps:
-      - run: git clone -b ${CIRCLE_BRANCH} https://github.com/jonbaldie/queue.git && cd queue && deno compile --allow-read --allow-write --allow-net --allow-env main.ts && cp ./queue /usr/bin/ && deno test --allow-read --allow-write --allow-net 
+      - run: apt-get update -yqq && apt-get install git -yqq && git clone -b ${CIRCLE_BRANCH} https://github.com/jonbaldie/queue.git && cd queue && deno compile --allow-read --allow-write --allow-net --allow-env main.ts && cp ./queue /usr/bin/ && deno test --allow-read --allow-write --allow-net 
 
 workflows:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: jonbaldie/queue
+      - image: denoland/deno:1.19.0
     steps:
-      - run: cd /queue && deno test --allow-read --allow-write --allow-net
+      - run: git clone -b ${CIRCLE_BRANCH} https://github.com/jonbaldie/queue.git && cd queue && deno compile --allow-read --allow-write --allow-net --allow-env main.ts && cp ./queue /usr/bin/ && deno test --allow-read --allow-write --allow-net 
 
 workflows:
   test:


### PR DESCRIPTION
Currently the Docker image associated with this repo is used for CI testing, which makes PRs a bit of a mess.

This PR uses the base Deno image instead and installs the relevant branch, so it's actually testing new code properly.