### PR TITLE
fix: use CIRCLE_SHA1 for checkout to survive squash-merge branch deletion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: denoland/deno:2.7.6
     steps:
-      - run: apt-get update -yqq && apt-get install git -yqq && git clone -b ${CIRCLE_BRANCH} https://github.com/jonbaldie/queue.git && cd queue && touch persist.dat && deno compile --allow-read --allow-write --allow-net --allow-env main.ts && cp ./queue /usr/bin/ && deno test --allow-read --allow-write --allow-net
+      - run: apt-get update -yqq && apt-get install git -yqq && git clone https://github.com/jonbaldie/queue.git && cd queue && git checkout ${CIRCLE_SHA1} && touch persist.dat && deno compile --allow-read --allow-write --allow-net --allow-env main.ts && cp ./queue /usr/bin/ && deno test --allow-read --allow-write --allow-net
 
 workflows:
   test:


### PR DESCRIPTION
## Problem

After a squash-merge, CircleCI triggers a post-merge build where `CIRCLE_BRANCH` is set to the now-deleted source branch. The current config does:

```bash
git clone -b ${CIRCLE_BRANCH} ...
```

This fails with `fatal: Remote branch <branch> not found` because squash-merging deletes the source branch.

Every squash-merge has been silently causing a post-merge CI failure on main.

## Fix

Switch from branch-based clone to SHA-based checkout:

```bash
git clone https://github.com/jonbaldie/queue.git && cd queue && git checkout ${CIRCLE_SHA1}
```

`CIRCLE_SHA1` is the exact commit SHA CircleCI is testing — always exists regardless of branch lifecycle.