### PR TITLE
chore: ignore generated mutation artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /queue
 /target/
 /node_modules/
-/.stryker-tmp/sandbox-*/
+/.stryker-tmp/
+/mutation/stryker-report.json
+/mutation/.stryker-ci-*.json
 /.claude/
 CLAUDE.md


### PR DESCRIPTION
## Summary

Ignore generated mutation reports, temporary Stryker configs, and the Stryker temp directory while keeping mutation source/configuration tracked.

## Verification

- Confirmed mutation/stryker-report.json is ignored with git check-ignore
- Confirmed .stryker-tmp/ is ignored
- git diff --check passes