### PR TITLE
refactor: clear middleware quality gate

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,12 +3,12 @@ import { RateLimiter } from "./rate_limiter.ts";
 export type HttpHandler = (request: Request, info?: Deno.ServeHandlerInfo) => Promise<Response> | Response;
 export type Middleware = (next: HttpHandler) => HttpHandler;
 
-const healthPattern = new URLPattern({ pathname: "/health" });
+const HEALTH_PATTERN = new URLPattern({ pathname: "/health" });
 
 export function withAuth(apiToken: string): Middleware {
     return (next: HttpHandler) => {
         return (request: Request, info?: Deno.ServeHandlerInfo) => {
-            if (healthPattern.exec(request.url)) {
+            if (HEALTH_PATTERN.exec(request.url)) {
                 return next(request, info);
             }
             const authHeader = request.headers.get("Authorization");
@@ -23,7 +23,7 @@ export function withAuth(apiToken: string): Middleware {
 export function withRateLimit(limiter: RateLimiter): Middleware {
     return (next: HttpHandler) => {
         return (request: Request, info?: Deno.ServeHandlerInfo) => {
-            if (healthPattern.exec(request.url)) {
+            if (HEALTH_PATTERN.exec(request.url)) {
                 return next(request, info);
             }
             const remoteAddr = info?.remoteAddr && info.remoteAddr.transport === "tcp"

--- a/tests/handler_test.ts
+++ b/tests/handler_test.ts
@@ -241,6 +241,16 @@ Deno.test("response body: rate limited returns 'Too many requests'", async () =>
     assertEquals(await res.text(), "Too many requests");
 });
 
+Deno.test("middleware: rate limiting runs before authentication", async () => {
+    const handler = makeHandler(undefined, undefined, 1);
+    const firstResponse = await handler(new Request("http://localhost/length/q"));
+    const secondResponse = await handler(new Request("http://localhost/length/q"));
+
+    assertEquals(firstResponse.status, 401);
+    assertEquals(secondResponse.status, 429);
+    assertEquals(await secondResponse.text(), "Too many requests");
+});
+
 Deno.test("response body: queues POST returns 'Method not allowed'", async () => {
     const handler = makeHandler();
     const res = await handler(new Request("http://localhost/queues", { method: "POST", headers: auth }));


### PR DESCRIPTION
Closes #33.

## What changed

- Renamed the shared health-route pattern to satisfy the pinned messcript constant-naming rule.
- Added a real-request canary proving rate limiting executes before authentication: the first unauthenticated request returns 401 and consumes the slot; the second returns 429.
- Added no suppression, exclusion, policy change, mock, or production behavior change.

## TDD evidence

- Structural red: `quality:unit -- middleware` reported `ConstantNamingConventions` for `healthPattern`.
- Structural green: the same command exits 0 after the minimal rename.
- Ordering red: under a temporary auth-first composition, the new canary failed with actual 401 vs expected 429.
- Ordering green: under the real rate-limit-first composition, the canary passes with 401 then 429.

## Validation

- Full Deno suite: 178 passed, including real socket startup/shutdown E2E tests.
- Handler public seam: 94 passed.
- `deno lint src/middleware.ts` passed.
- Two-axis standards/spec review passed with no findings.
- GitHub Actions will run Test → Mutasaurus → Stryker on this PR.