### PR TITLE
refactor: clear Persist Engine quality gate

### DIFF
--- a/src/persist.ts
+++ b/src/persist.ts
@@ -55,8 +55,11 @@ export class FileStore<T = string> implements QueueStore<T> {
                 const chunks: Uint8Array[] = [];
                 const chunk = new Uint8Array(4096);
                 let totalRead = 0;
-                let read: number | null;
-                while ((read = file.readSync(chunk)) !== null && read > 0) {
+                while (true) {
+                    const read = file.readSync(chunk);
+                    if (read === null || read <= 0) {
+                        break;
+                    }
                     chunks.push(chunk.slice(0, read));
                     totalRead += read;
                 }
@@ -74,11 +77,11 @@ export class FileStore<T = string> implements QueueStore<T> {
                 file.unlockSync();
                 file.close();
             }
-        } catch (_e) {
-            if (_e instanceof Deno.errors.NotFound) {
+        } catch (error) {
+            if (error instanceof Deno.errors.NotFound) {
                 return [];
             }
-            throw _e;
+            throw error;
         }
     }
 
@@ -107,5 +110,5 @@ export class MemoryStore<T = string> implements QueueStore<T> {
         return [...this.events];
     }
 
-    public dir(_dir: string): void {}
+    public dir(): void {}
 }

--- a/tests/persist_test.ts
+++ b/tests/persist_test.ts
@@ -25,6 +25,18 @@ Deno.test("persist MemoryStore.saveEvent() appends", () => {
     assertEquals(p.loadState().length, 1);
 });
 
+Deno.test("persist MemoryStore replays events in append order", () => {
+    const p = new Persistency.MemoryStore();
+    p.saveEvent("q", "first", true);
+    p.saveEvent("q", "second", true);
+    p.saveEvent("q", "first", false);
+
+    assertEquals(
+        p.loadState().map((event) => [event.payload, event.enqueue]),
+        [["first", true], ["second", true], ["first", false]],
+    );
+});
+
 Deno.test("persist MemoryStore.clear() clears events", () => {
     const p = new Persistency.MemoryStore();
     p.saveEvent("q", "anything", true);
@@ -95,6 +107,69 @@ Deno.test("persist FileStore.saveEvent() does not overwrite existing content", (
     const events = p.loadState();
     assertEquals(events[0].payload, "line1");
     assertEquals(events[1].payload, "line2");
+    Deno.removeSync(tmpDir, { recursive: true });
+});
+
+Deno.test("persist FileStore.saveEvent() waits for an existing file lock", async () => {
+    const tmpDir = Deno.makeTempDirSync();
+    const markerPath = tmpDir + "/ready";
+    const persistPath = tmpDir + "/persist.dat";
+    const persistModule = new URL("../src/persist.ts", import.meta.url).href;
+    const lockedFile = Deno.openSync(persistPath, { write: true, create: true });
+    lockedFile.lockSync(true);
+
+    const childCode = `
+        import { FileStore } from ${JSON.stringify(persistModule)};
+        Deno.writeTextFileSync(${JSON.stringify(markerPath)}, "ready");
+        const store = new FileStore();
+        store.dir(${JSON.stringify(tmpDir)});
+        store.saveEvent("q", "from-child", true);
+    `;
+    const child = new Deno.Command(Deno.execPath(), {
+        args: ["eval", "--no-config", childCode],
+        stdout: "null",
+        stderr: "piped",
+    }).spawn();
+    const statusPromise = child.status;
+    const stderrPromise = new Response(child.stderr).text();
+
+    try {
+        let markerReady = false;
+        for (let attempt = 0; attempt < 500 && !markerReady; attempt++) {
+            try {
+                markerReady = Deno.statSync(markerPath).isFile;
+            } catch (error) {
+                if (!(error instanceof Deno.errors.NotFound)) {
+                    throw error;
+                }
+            }
+            await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        if (!markerReady) {
+            const status = await statusPromise;
+            throw new Error(
+                `lock contender exited ${status.code}: ${await stderrPromise}`,
+            );
+        }
+        const completedWhileLocked = await Promise.race([
+            statusPromise.then(() => true),
+            new Promise<false>((resolve) => setTimeout(() => resolve(false), 100)),
+        ]);
+        assertEquals(completedWhileLocked, false);
+    } finally {
+        lockedFile.unlockSync();
+        lockedFile.close();
+    }
+
+    const status = await statusPromise;
+    assertEquals(
+        status.success,
+        true,
+        await stderrPromise,
+    );
+    const store = new Persistency.FileStore();
+    store.dir(tmpDir);
+    assertEquals(store.loadState()[0].payload, "from-child");
     Deno.removeSync(tmpDir, { recursive: true });
 });
 


### PR DESCRIPTION
Closes #34.

## What changed

- Replaced assignment inside the file-read loop with an explicit read/break cycle.
- Renamed the caught error and removed MemoryStore’s unused no-op `dir` parameter.
- Added ordered multi-event MemoryStore replay coverage.
- Added real cross-process FileStore lock contention coverage: a child `saveEvent` must block until the parent releases the OS file lock.
- Added no suppression, exclusion, policy change, or mock.

## TDD evidence

- Persist gate red on `IfStatementAssignment`, `_e`, and `_dir`; green after the minimal refactor.
- Reversing MemoryStore replay makes the new order test fail.
- Removing `FileStore.saveEvent` locking makes the child complete while the parent lock is held and the new lock test fail.
- Restored production passes both canaries.

## Validation

- Full Deno suite: 180 passed, including real socket E2E and child-process lock contention.
- Persist/manager focused suite: 49 passed.
- `quality:unit -- persist-engine` exits 0.
- `deno lint src/persist.ts` passes.
- Two-axis standards/spec review passes with no findings.
- GitHub Actions will run Test → Mutasaurus → Stryker.