### PR TITLE
Enforce the aggregate production quality gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,21 @@ jobs:
           touch persist.dat
           npx --no-install stryker run mutation/stryker.config.json
           node mutation/stryker_check.js
+
+  production-quality:
+    name: Production quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Run aggregate production quality gate
+        run: npm run quality:production

--- a/scripts/messcript.mjs
+++ b/scripts/messcript.mjs
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const messcriptRepository = "https://github.com/quality-gates/messcript.git";
@@ -21,6 +21,10 @@ const productionUnits = new Map([
   ["http-handler", ["src/handler.ts"]],
   ["entrypoint", ["main.ts"]],
 ]);
+const requiredComplexityRules = [
+  "CyclomaticComplexity",
+  "NPathComplexity",
+];
 
 function run(command, args, cwd) {
   const result = spawnSync(command, args, {
@@ -133,6 +137,34 @@ function requestedPaths(unitName) {
   return paths;
 }
 
+async function reportAggregatePolicy() {
+  const rulesets = await import(
+    pathToFileURL(join(toolRoot, "dist", "rulesets.js")).href
+  );
+  const selectedRules = new Set(
+    rulesets.loadRulesets(["typescript"]).selections.map(
+      (selection) => selection.name,
+    ),
+  );
+  const missingRules = requiredComplexityRules.filter(
+    (ruleName) => !selectedRules.has(ruleName),
+  );
+  if (missingRules.length > 0) {
+    throw new Error(
+      `typescript policy is missing required rules: ${missingRules.join(", ")}`,
+    );
+  }
+
+  console.log(
+    `Production quality scope (${productionUnits.size}): ${
+      [...productionUnits.keys()].join(", ")
+    }`,
+  );
+  console.log(
+    `Required complexity rules: ${requiredComplexityRules.join(", ")}`,
+  );
+}
+
 const unitName = process.argv[2] ?? "all";
 
 try {
@@ -141,6 +173,9 @@ try {
   if (acquireExit !== 0) {
     process.exitCode = acquireExit;
   } else {
+    if (unitName === "all") {
+      await reportAggregatePolicy();
+    }
     process.exitCode = run(
       "node",
       [messcriptCli, paths.join(","), "text", "typescript", "--color=never"],


### PR DESCRIPTION
Closes #37

## What changed

- Added a Node 22 `Production quality` GitHub Actions job that runs `npm run quality:production` on every applicable workflow run.
- Kept the Deno 2.7.6 Test → Mutasaurus → Stryker chain unchanged.
- Made clean aggregate output name all eight production units and verify/report `CyclomaticComplexity` plus `NPathComplexity` from the pinned `typescript` policy before enforcing the full report.

## Why

Per-unit remediation is complete, but CI did not yet enforce the complete production surface. This final gate prevents a clean unit from concealing findings elsewhere and keeps policy selection auditable even when the report has zero findings.

## Validation

- `npm run quality:production` — 8 units, required complexity rules, zero findings
- Temporary real production finding — aggregate exited 2 and reported it
- Workflow YAML parse and Node syntax check
- `deno test --frozen=false --allow-all` — 180 passed
- Mutasaurus — 98% overall, every file ≥80%
- Stryker — 94.72% overall, every file ≥80%
- Live process smoke — startup, unauthenticated health, authenticated enqueue, FIFO dequeue, persistence flush, SIGTERM exit 0
- Two-axis review: Standards pass; Spec pass
